### PR TITLE
Bigger key

### DIFF
--- a/aries-common/src/main/java/org/apache/aries/common/Constants.java
+++ b/aries-common/src/main/java/org/apache/aries/common/Constants.java
@@ -42,4 +42,6 @@ public final class Constants {
 
   public static final long ONE_GB = ONE_MB * 1024;
 
+  public static final int TEN = 10;
+
 }

--- a/aries-common/src/main/java/org/apache/aries/common/Constants.java
+++ b/aries-common/src/main/java/org/apache/aries/common/Constants.java
@@ -42,6 +42,6 @@ public final class Constants {
 
   public static final long ONE_GB = ONE_MB * 1024;
 
-  public static final int TEN = 10;
+  public static final int DEFAULT_KEY_LENGTH_PW = 10;
 
 }

--- a/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
+++ b/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
@@ -98,6 +98,7 @@ public class PutWorker extends AbstractHBaseToy {
     example(buffer_size.key(), "1024");
     example(running_time.key(), "300");
     example(value_kind.key(), "FIXED");
+    example(key_length.key(), "10");
   }
 
   @Override

--- a/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
+++ b/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
@@ -65,7 +65,7 @@ public class PutWorker extends AbstractHBaseToy {
       EnumParameter.newBuilder("pw.value_kind", VALUE_KIND.FIXED, VALUE_KIND.class)
                    .setDescription("Value is fixed or random generated").opt();
   private final Parameter<Integer> key_length =
-      IntParameter.newBuilder("pw.key_length").setDefaultValue(Constants.TEN).
+      IntParameter.newBuilder("pw.key_length").setDefaultValue(Constants.DEFAULT_KEY_LENGTH_PW).
           setDescription("How long will be the generated key.").opt();
 
   enum VALUE_KIND {

--- a/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
+++ b/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
@@ -66,7 +66,7 @@ public class PutWorker extends AbstractHBaseToy {
                    .setDescription("Value is fixed or random generated").opt();
   private final Parameter<Integer> key_length =
       IntParameter.newBuilder("pw.key_length").setDefaultValue(Constants.DEFAULT_KEY_LENGTH_PW).
-          setDescription("The size of the generated key.").opt();
+          setDescription("The length of the generated key in bytes.").opt();
 
   enum VALUE_KIND {
     RANDOM, FIXED

--- a/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
+++ b/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
@@ -66,7 +66,7 @@ public class PutWorker extends AbstractHBaseToy {
                    .setDescription("Value is fixed or random generated").opt();
   private final Parameter<Integer> key_length =
       IntParameter.newBuilder("pw.key_length").setDefaultValue(Constants.DEFAULT_KEY_LENGTH_PW).
-          setDescription("How long will be the generated key.").opt();
+          setDescription("The size of the generated key.").opt();
 
   enum VALUE_KIND {
     RANDOM, FIXED

--- a/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
+++ b/aries-hbase/src/main/java/org/apache/aries/PutWorker.java
@@ -64,6 +64,9 @@ public class PutWorker extends AbstractHBaseToy {
   private final Parameter<Enum> value_kind =
       EnumParameter.newBuilder("pw.value_kind", VALUE_KIND.FIXED, VALUE_KIND.class)
                    .setDescription("Value is fixed or random generated").opt();
+  private final Parameter<Integer> key_length =
+      IntParameter.newBuilder("pw.key_length").setDefaultValue(Constants.TEN).
+          setDescription("How long will be the generated key.").opt();
 
   enum VALUE_KIND {
     RANDOM, FIXED
@@ -185,7 +188,7 @@ public class PutWorker extends AbstractHBaseToy {
       try {
         mutator = connection.getBufferedMutator(param);
         while (running) {
-          String k = ToyUtils.generateRandomString(10);
+          String k = ToyUtils.generateRandomString(key_length.value());
           byte[] value = (kind == VALUE_KIND.FIXED) ?
               ToyUtils.generateBase64Value(k) :
               Bytes.toBytes(ToyUtils.generateRandomString(22));


### PR DESCRIPTION
Support customize the key length of put worker. In fix mode, the value will be corresponding base64, so that its length will also grow. For WAL blocking problem reproduction.